### PR TITLE
fix(actions): fix conditional step syntax

### DIFF
--- a/lint-python/action.yml
+++ b/lint-python/action.yml
@@ -10,7 +10,7 @@ runs:
   using: composite
   steps:
     - run: find ${{ inputs.exclude_trailing_comma_path }} -name '*.py' | xargs poetry run add-trailing-comma --exit-zero-even-if-changed --py36-plus
-      if: ${{ inputs.exclude_trailing_comma_path }} != ''
+      if: ${{ inputs.exclude_trailing_comma_path != '' }}
       shell: bash
 
     - run: find . -name '*.py' | xargs poetry run add-trailing-comma --py36-plus


### PR DESCRIPTION
I noticed this when opening more pull requests for using the composite action. The syntax here was incorrect, the step always got executed. This is now fixed.