### PR TITLE
fix(lint-python): remove `--py36-plus` as it's a noop in latest `add-…

### DIFF
--- a/lint-python/action.yml
+++ b/lint-python/action.yml
@@ -13,7 +13,7 @@ runs:
       if: ${{ inputs.exclude_trailing_comma_path != '' }}
       shell: bash
 
-    - run: find . -name '*.py' | xargs poetry run add-trailing-comma --py36-plus
+    - run: find . -name '*.py' | xargs poetry run add-trailing-comma
       shell: bash
 
     - run: poetry run flake8


### PR DESCRIPTION
```
> Run find . -name '*.py' | xargs poetry run add-trailing-comma --py36-plus
WARNING: --py35-plus / --py36-plus do nothing
```