### PR TITLE
Feature/add json formatter to lint python

### DIFF
--- a/lint-python/action.yml
+++ b/lint-python/action.yml
@@ -9,7 +9,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - run: find ${{ inputs.exclude_trailing_comma_path }} -name '*.py' | xargs poetry run add-trailing-comma --exit-zero-even-if-changed --py36-plus
+    - run: find ${{ inputs.exclude_trailing_comma_path }} -name '*.py' | xargs poetry run add-trailing-comma --exit-zero-even-if-changed
       if: ${{ inputs.exclude_trailing_comma_path != '' }}
       shell: bash
 

--- a/lint-python/action.yml
+++ b/lint-python/action.yml
@@ -18,3 +18,8 @@ runs:
 
     - run: poetry run flake8
       shell: bash
+
+    - run: find . -name '*.json' -exec python -m json.tool --indent 2 --no-ensure-ascii {} {} \;
+      shell: bash
+
+    - uses: moneymeets/moneymeets-composite-actions/check-git-diff@master


### PR DESCRIPTION
Does anyone know why do we run `poetry run add-trailing-comma` two times? `inputs.exclude_trailing_comma_path` has a default value. So we can just remove the second call and remove `if: ${{ inputs.exclude_trailing_comma_path != '' }}` to handle both cases.

https://moneymeets.atlassian.net/browse/MD-6983