### PR TITLE
fix(lint-python): put JSON formatter before add trailing comma

### DIFF
--- a/lint-python/action.yml
+++ b/lint-python/action.yml
@@ -9,17 +9,22 @@ inputs:
 runs:
   using: composite
   steps:
+    - run: find . -name '*.json' -exec python -m json.tool --indent 2 --no-ensure-ascii {} {} \;
+      shell: bash
+
+    - uses: moneymeets/moneymeets-composite-actions/check-git-diff@master
+
+    # Add trailing commas only for the excluded files, and return a zero exit code
+    # even if there are changes in the files. This is done so that in the next step,
+    # when add-trailing-comma is run again, the command can return a non-zero exit code
+    # (and thus fail the pipeline), if any changes are made.
     - run: find ${{ inputs.exclude_trailing_comma_path }} -name '*.py' | xargs poetry run add-trailing-comma --exit-zero-even-if-changed
       if: ${{ inputs.exclude_trailing_comma_path != '' }}
       shell: bash
 
+    # Returns non-zero exit code if any changes are made
     - run: find . -name '*.py' | xargs poetry run add-trailing-comma
       shell: bash
 
     - run: poetry run flake8
       shell: bash
-
-    - run: find . -name '*.json' -exec python -m json.tool --indent 2 --no-ensure-ascii {} {} \;
-      shell: bash
-
-    - uses: moneymeets/moneymeets-composite-actions/check-git-diff@master


### PR DESCRIPTION
This is what I'm afraid of in the previous PR. The order of the add trailing comma and JSON formatter is important since we're add trailing commas in 2 steps and keep changed files. https://github.com/moneymeets/django-insurance-api-v2/actions/runs/6295791250/job/17089608332?pr=488

Changing the commands order will help. Another solution is to change the add trailing comma as I suggested in the https://github.com/moneymeets/moneymeets-composite-actions/pull/8#issuecomment-1702323482