### PR TITLE
feat(lint-python): change JSON formatter command to return non-zero status code on error

### DIFF
--- a/lint-python/action.yml
+++ b/lint-python/action.yml
@@ -9,7 +9,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - run: find . -name '*.json' -exec python -m json.tool --indent 2 --no-ensure-ascii {} {} \;
+    - run: find . -name '*.json' -type f -print0 | xargs -I {} -0 python -m json.tool --indent 2 --no-ensure-ascii {} {}
       shell: bash
 
     - uses: moneymeets/moneymeets-composite-actions/check-git-diff@master


### PR DESCRIPTION
The old command always returned a zero status code even if the `json.tool` found an incorrectly formatter JSON file. https://github.com/moneymeets/django-insurance-api-v2/pull/542#issuecomment-1738595642