### PR TITLE
feat(action): replace all slashes with dashes in `build-and-push-image`

### DIFF
--- a/build-and-push-image/action.yml
+++ b/build-and-push-image/action.yml
@@ -72,7 +72,7 @@ runs:
         if [[ "${{ github.ref_name }}" == "master" ]]; then
           IMAGE_TAG=master-${{ github.sha }}
         else
-          IMAGE_TAG=$(echo ${{ github.ref_name }} | awk '{print tolower($0)}' | sed -e 's|/|-|')
+          IMAGE_TAG=$(echo ${{ github.ref_name }} | awk '{print tolower($0)}' | sed -e 's|/|-|g')
         fi
 
         echo "image-url-with-tag=${IMAGE_URL}:${IMAGE_TAG}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
It seems that Renovate discovered a bug in the action here:

https://github.com/moneymeets/sepacetamol/pull/94

Only the first slash in the branch name is replaced and so nested namespaces are not supported.

Is it meant to be this way, or is this a mistake?