### PR TITLE
feat(action): introduce action to block poetry version downgrade

### DIFF
--- a/block-poetry-version-downgrade/action.yml
+++ b/block-poetry-version-downgrade/action.yml
@@ -1,0 +1,38 @@
+name: Block Poetry version downgrade
+description: Block Poetry version downgrade
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v4
+      with:
+        path: master
+        ref: master
+        sparse-checkout: |
+          poetry.lock
+
+    - uses: moneymeets/moneymeets-composite-actions/detect-python-version@master
+      id: detect-version-on-master
+      with:
+        working_directory: ${{ format('{0}/master', github.workspace) }}
+
+    - uses: actions/checkout@v4
+      with:
+        sparse-checkout: |
+          poetry.lock
+
+    - uses: moneymeets/moneymeets-composite-actions/detect-python-version@master
+      id: detect-version-on-feature-branch
+
+    - shell: bash
+      env:
+        MASTER_POETRY_VERSION: ${{ steps.detect-version-on-master.outputs.poetry-version }}
+        FEATURE_POETRY_VERSION: ${{ steps.detect-version-on-feature-branch.outputs.poetry-version }}
+      run: |
+        if dpkg --compare-versions "$FEATURE_POETRY_VERSION" "lt" "$MASTER_POETRY_VERSION"; then
+          echo "::error file=poetry.lock,line=1::Poetry version downgrade from ${MASTER_POETRY_VERSION} to ${FEATURE_POETRY_VERSION} not allowed"
+          exit 1
+        else
+          echo "Passed, master=$MASTER_POETRY_VERSION; feature=$FEATURE_POETRY_VERSION"
+        fi
+


### PR DESCRIPTION
This can be see in action
https://github.com/moneymeets/django-securities-api/actions/runs/7913643281/job/21601714330

The above branch in securities API was prepared with a downgraded version of poetry so it fails as expected

Thought process
- checkout master 
- detect version of master using our custom detect composite action
- checkout feature branch
- detect version of feature branch using our custom detect composite action
- compare this versions
- fail if there is a downgrade