### PR TITLE
fix(block-poetry-version-downgrade): cleanup checkout after performin…

### DIFF
--- a/block-poetry-version-downgrade/action.yml
+++ b/block-poetry-version-downgrade/action.yml
@@ -35,3 +35,5 @@ runs:
           echo "Passed, master=$MASTER_POETRY_VERSION; feature=$FEATURE_POETRY_VERSION"
         fi
 
+    - run: rm -r "${{ format('{0}/master', github.workspace) }}" && rm -r "${{ format('{0}/feature-branch', github.workspace) }}"
+      shell: bash


### PR DESCRIPTION
We need to clean up the checkout directory afterward, otherwise our `git diff`action is failing, see https://github.com/moneymeets/django-insurance-api-v2/actions/runs/8067688214