### PR TITLE
feat(action): change push_to_ecr default to true

### DIFF
--- a/build-and-push-image/action.yml
+++ b/build-and-push-image/action.yml
@@ -5,7 +5,7 @@ inputs:
   push_to_ecr:
     description: Determines whether the image should be pushed
     required: false
-    default: "false"  # ToDo: Switch default after ECR repositories are created
+    default: "true"
   ecr_repository:
     description: ECR repository to push image in
     required: true


### PR DESCRIPTION
Now that the ECR repositories are created, we can change the default `push_to_ecr` to true