### PR TITLE
Feature/add action to upload openapi specs

### DIFF
--- a/set-api-deployment-hash/action.yml
+++ b/set-api-deployment-hash/action.yml
@@ -1,0 +1,20 @@
+name: Set deployment hash
+description: Write SHA for current deployment to S3
+
+inputs:
+  s3-bucket:
+    description: S3 bucket
+    required: true
+  deployment-reference-file:
+    description: Filename to write the hash to and upload to S3
+    required: false
+    default: 'active-deployment-sha-${{ github.event.deployment.environment }}.txt'
+
+runs:
+  using: composite
+  steps:
+    - name: Update active deployment sha
+      run: |
+        echo -e "${{ github.sha }}" > ${{ inputs.deployment-reference-file }}
+        aws s3 cp ${{ inputs.deployment-reference-file }} s3://${{ inputs.s3-bucket }}/${{ github.event.repository.name }}/
+      shell: bash

--- a/upload-openapi-specs/action.yml
+++ b/upload-openapi-specs/action.yml
@@ -1,0 +1,29 @@
+name: Upload specs
+description: Upload OpenAPI spec files to S3
+
+inputs:
+  s3-bucket:
+    description: S3 bucket
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Set environment variables
+      run: echo "S3_ARTIFACT_PATH_WITH_SHA=s3://${{ inputs.s3-bucket }}/${{ github.event.repository.name }}/${{ github.sha }}" >> $GITHUB_ENV
+      shell: bash
+
+    - name: Upload OpenAPI spec files to S3
+      run: aws s3 sync ${{ env.API_SPEC_PATH }} ${{ env.S3_ARTIFACT_PATH_WITH_SHA }}/${{ github.event.repository.name }}/${{ env.API_SPEC_PATH }}
+      shell: bash
+      env:
+        API_SPEC_PATH: api/spec/
+
+    - name: Upload moneymeets-specs files to S3
+      run: |
+        # Get path for installed moneymeets-specs dependency
+        MONEYMEETS_SPECS_VIRTUALENV_PATH=$(find $(poetry env info --path)/lib -wholename */${{ env.MONEYMEETS_SPECS_PATH }})
+        aws s3 sync $MONEYMEETS_SPECS_VIRTUALENV_PATH ${{ env.S3_ARTIFACT_PATH_WITH_SHA }}/moneymeets-specs/${{ env.MONEYMEETS_SPECS_PATH }} --exclude '*' --include '*.yml' --include '*.yaml'
+      shell: bash
+      env:
+        MONEYMEETS_SPECS_PATH: "moneymeets/specs/moneymeets"


### PR DESCRIPTION
In this PR I've prepared shared actions to upload OpenAPI spec files including shared specs to S3 and update the deployed version (txt file with sha in S3).

The upload of the spec files can be called in our `ci.yml` whereas the update of the hash will be called in our `deploy.yml`.

I've tested both actions, see

Example Pipeline: 
https://github.com/moneymeets/django-insurance-api-v2/actions/runs/15560064576/job/43809878322

I've added the following lines:
```
# ToDo: switch to @master
- uses: moneymeets/moneymeets-composite-actions/upload-openapi-specs@feature/add-action-to-upload-openapi-specs
  with:
    s3-bucket: ${{ vars.S3_PIPELINE_ARTIFACTS }}

# ToDo: Remove, only for testing in ci.yml. Should be in deploy.yml
- uses: moneymeets/moneymeets-composite-actions/set-api-deployment-hash@feature/add-action-to-upload-openapi-specs
  with:
    s3-bucket: ${{ vars.S3_PIPELINE_ARTIFACTS }}
    # ToDo: remove file name
    deployment-reference-file: 'active-deployment-sha-dev.txt'
```

As you can see, we will use `S3_PIPELINE_ARTIFACTS` from organization variables.