### PR TITLE
feat(action): extend Python version parsing in detect-python-version action

### DIFF
--- a/detect-python-version/action.yml
+++ b/detect-python-version/action.yml
@@ -27,7 +27,7 @@ runs:
     - id: detect-versions
       run: |
         if [ -z "${{ inputs.python_version }}" ] ; then
-            PYTHON_VERSION="$(sed -n -e '/^\[metadata\]/,/^\[/p' poetry.lock | sed -n -e 's/^python-versions[[:space:]]*=[[:space:]]*//p' | tr -d \"'[:space:]'\'~^)"
+            PYTHON_VERSION="$(sed -n -e '/^\[metadata\]/,/^\[/p' poetry.lock | sed -n -e 's/^python-versions[[:space:]]*=[[:space:]]*"~[=]*\([0-9]*\.[0-9]*\).*/\1/p')"
         else
             PYTHON_VERSION="${{ inputs.python_version }}"
         fi


### PR DESCRIPTION
Fix should allow us to use `~=` https://python-poetry.org/docs/dependency-specification/#compatible-release-requirements instead of `~` https://python-poetry.org/docs/dependency-specification/#tilde-requirements when specifying Python version in `pyproject.toml` to resolve ruff warning in PyCharm

<img width="1483" height="274" alt="image" src="https://github.com/user-attachments/assets/67c9138b-1545-494c-bca7-3839e57bd243" />

Fix is backward compatible and can be deployed and use already now. But there is still a question how to declare Python version with `~=`. To have the same behavior we should replace `~3.12` with `~=3.12.12`. This forces us to pin specific patch version to restrict Python version to the range `>=3.12.12 <3.13`. This restricts us to use specific Python version in CI without chance to automatically update it to the latest patch version without manual intervention. Using `~=3.12` allows any version equal or higher than 3.12 to use in the project which is not what we want.

Another option is to extend shell command to remove patch level version from Python version string. In this case we can set `requires-python` to `~=3.12.0` and always use latest Python version in the 3.12 branch and locally.