### PR TITLE
feat(action): improve Python version parsing to support >= Python version specifications

### DIFF
--- a/detect-python-version/action.yml
+++ b/detect-python-version/action.yml
@@ -27,7 +27,7 @@ runs:
     - id: detect-versions
       run: |
         if [ -z "${{ inputs.python_version }}" ] ; then
-            PYTHON_VERSION="$(sed -n -e '/^\[metadata\]/,/^\[/p' poetry.lock | sed -n -e 's/^python-versions[[:space:]]*=[[:space:]]*"~[=]*\([0-9]*\.[0-9]*\).*/\1/p')"
+            PYTHON_VERSION="$(sed -n -e '/^\[metadata\]/,/^\[/p' poetry.lock | sed -n -e 's/^python-versions[[:space:]]*=[[:space:]]*"[~>][=]*\([0-9]*\.[0-9]*\).*/\1/p')"
         else
             PYTHON_VERSION="${{ inputs.python_version }}"
         fi


### PR DESCRIPTION
New regex pattern won't work for https://github.com/moneymeets/youtrack-sdk/blob/master/poetry.lock#L591 PR contains fix to support both cases `>=` and `~=`.